### PR TITLE
use inventory variables to simplify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Restart from fresh again:
 ## Ansible Command
 If your interested in knowing what command would initiate an ansible provision:
 
-    ansible-playbook -i inventory.yml --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbook.yml
+    ansible-playbook -i inventory.yml playbook.yml
 
 ## Testing
 Want to test the nodejs playbook?
 
-    ansible-playbook -i inventory.yml --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbooks.yml --tags nodejs
+    ansible-playbook -i inventory.yml playbooks.yml --tags nodejs
 
 ## Having Problems?
 

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,3 +1,7 @@
 [nodes]
 ubuntu1310 ansible_ssh_port=22 ansible_ssh_host=172.16.1.10
 centos65 ansible_ssh_port=22 ansible_ssh_host=172.16.1.11
+
+[nodes:vars]
+ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
+ansible_ssh_user=vagrant


### PR DESCRIPTION
Hi Jason,
While playing with this test suite, I noticed that the ansible-playbook command has a lot of repetition and can be simplified considerably using vars in the inventory file. What do you think?
