### PR TITLE
simplify usage, closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,15 @@ Restart from fresh again:
 ## Ansible Command
 If you're interested in knowing what command would initiate an ansible provision:
 
-    ansible-playbook -i inventory.yml --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbook.yml
+    ansible-playbook playbook.yml
 
 ## Testing
 Want to test the nodejs playbook?
 
-    ansible-playbook -i inventory.yml --private-key=~/.vagrant.d/insecure_private_key -u vagrant playbook.yml --tags nodejs
+    ansible-playbook playbook.yml --tags nodejs
 
 ## Having Problems?
 
 1. Ansible cannot ssh, as it reports security key issues.
   - Remove the entry for `172.16.1.10` in `~/.ssh/known_hosts` file
 1. Create an github issue
-

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+
+hostfile   = inventory.yml

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,6 +1,11 @@
 [nodes]
-ubuntu1310 ansible_ssh_port=22 ansible_ssh_host=172.16.1.10
-centos65 ansible_ssh_port=22 ansible_ssh_host=172.16.1.11
+ubuntu1310 ansible_ssh_host=172.16.1.10
+centos65 ansible_ssh_host=172.16.1.11
+
+[nodes:vars]
+ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
+ansible_ssh_user=vagrant
+ansible_ssh_port=22
 
 [ubuntu]
 ubuntu1310


### PR DESCRIPTION
Hi Jason,
This is sort of a repeat of #2, but I went a step further and added an ansible.cfg file that specifies the inventory file. Now all you need to do to run the playbook is `ansible-playbook playbook.yml`
