### PR TITLE
pass nodejs_path var to nodejs integration test

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -25,4 +25,4 @@
     - { role: ansible-nginx, tags:['nginx'] }
 
 - include: tests/integration-tests.yml tags=mesos
-- include: roles/ansible-nodejs/tests/integration-tests.yml tags=nodejs
+- include: roles/ansible-nodejs/tests/integration-tests.yml tags=nodejs nodejs_path=/usr/


### PR DESCRIPTION
In combination with https://github.com/AnsibleShipyard/ansible-nodejs/pull/17, this enables the nodejs tests to pass.
